### PR TITLE
cosm->xively

### DIFF
--- a/nodeapp/routes/index.js
+++ b/nodeapp/routes/index.js
@@ -9,7 +9,7 @@ module.exports = function (app) {
     app.get('/temp', function(req, res) {
         res.render('cosm');
     });
-    app.get('/cosm', function(req, res) {
+    app.get('/xively', function(req, res) {
         res.render('cosm');
     });
     app.get('/', function (req, res) {


### PR DESCRIPTION
cosm се преименувале во xively направиле s/cosm/xively и сега twiter triger-от носи кон status.spodeli.org/xively а неможе да се смени triger-от на legacy feed-ови.
